### PR TITLE
Desktop file for browsing in a Disposable VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,76 @@
-# qubes-desktop
-Desktop files for Qubes tools
+# Desktop files for Qubes tools
 
-## qvm-open-in-dvm
-A Desktop file for qvm-open-in-dvm. Meant to be placed in ~/.local/share/applications or /usr/share/applications. To get the correct icon, copy /usr/share/qubes/icons from dom0 to /usr/share/icons/Qubes.
+The freedesktop
+[Desktop Entry specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html)
+provides a standard for applications to integrate into a desktop environment.
+Desktop entries are the configuration files that describe how an application
+is launched and which data it can handle.
+They also configure how an application appears in a menu with an icon, which
+is subject to the related
+[menu specification](https://specifications.freedesktop.org/menu-spec/menu-spec-latest.html)
+standard.
 
-### Usage
-Depending on the file manager, there are different ways to set the default application to open a set of files. However, with Thunar, right click the file you want to open, select "Open in Disposable VM", and check the "Use as default for this kind of file" box. In Nautilus, right click the file you want to open, select the "Open With" tab, select "Open in Disposable VM", and click the "Set ad default" button.
+In [Qubes OS](https://www.qubes-os.org/) proper Desktop Entry settings help
+you to prevent from accidentally opening suspicious files or URLs in a
+privileged VM.
+
+## qvm-open-in-dvm.desktop
+
+A Desktop file for opening *local files* with qvm-open-in-dvm.
+
+## qvm-browse-in-dvm.desktop
+
+A Desktop file for opening *URL schemas* with qvm-open-in-dvm.
+
+## Installation
+
+The Desktop files are meant to be placed in ~/.local/share/applications or
+/usr/share/applications.
+
+To get the correct icon, copy /usr/share/qubes/icons from dom0 to the AppVM's
+/usr/share/icons/Qubes.
+
+## Usage
+
+Depending on the file manager, there are different ways to set the
+default application.
+Here are some examples.
+
+### Thunar (local files)
+
+In the AppVM's Thunar window, right click the file you want to open, select
+"Open in Disposable VM", and check the "Use as default for this kind of file"
+box.
+
+### Nautilus (local files)
+
+In the AppVM's Nautilus window, right click the file you want to open, select
+the "Open With" tab, select "Open in Disposable VM", and click the "Set ad
+default" button.
+
+### Xdg-settings (URL schemas)
+
+In the AppVM's terminal window, set the default browser:
+
+~~~
+xdg-settings set default-web-browser qvm-browse-in-dvm.desktop
+~~~
+
+### Checking the Desktop Entry settings
+
+You can check the Desktop Entry setting for any file with the following
+command:
+
+~~~
+xdg-mime query default $(mimetype <file>|awk '{print $2}')
+~~~
+
+The output (for any suspicious file type) should be "qvm-open-in-dvm.desktop".
+
+Check the default browser setting with:
+
+~~~
+xdg-settings get default-web-browser
+~~~
+
+The output should be "qvm-browse-in-dvm.desktop".

--- a/qvm-browse-in-dvm.desktop
+++ b/qvm-browse-in-dvm.desktop
@@ -1,0 +1,19 @@
+[Desktop Entry]
+Type=Application
+Encoding=UTF-8
+Name=Browse in Disposable VM
+Comment=Open a suspicious link in a Disposable VM
+Comment[de]=Im Internet surfen mit DVM
+Comment[fi]=Selaa Internetin WWW-sivuja DVM:ssä
+Comment[sv]=Surfa på webben i DVM
+GenericName=Web Browser
+GenericName[de]=Webbrowser
+GenericName[fi]=WWW-selain
+GenericName[sv]=Webbläsare
+TryExec=/usr/bin/qvm-open-in-dvm
+Exec=/usr/bin/qvm-open-in-dvm %u
+X-MultipleArgs=false
+Icon=/usr/share/icons/Qubes/dispvm-gray.png
+Terminal=false
+Categories=Qubes;Utility;Network;WebBrowser;
+MimeType=x-scheme-handler/unknown;x-scheme-handler/about;text/html;text/xml;application/xhtml+xml;application/xml;application/vnd.mozilla.xul+xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;


### PR DESCRIPTION
Because of the parameter '%f', qvm-open-in-dvm.desktop only opens local files and doesn't work for URL schemes. I added a new .desktop file, qvm-browse-in-dvm.desktop, which works with URL schemes (%u).

I also wrote some more detailed instructions into README.md.